### PR TITLE
Set uniform in ishader

### DIFF
--- a/ChamberLib.OpenTK/BuiltinShaders.cs
+++ b/ChamberLib.OpenTK/BuiltinShaders.cs
@@ -66,7 +66,7 @@ void main(void)
     vec3 position = in_position;
     vec4 transformed = worldViewProj * vec4(position, 1);
 
-    vf_position_ws = (world * vec4(position, 0)).xyz;
+    vf_position_ws = (world * vec4(position, 1)).xyz;
 
     vf_normal_ws = (world * vec4(in_normal, 0)).xyz;
 

--- a/ChamberLib.OpenTK/BuiltinShaders.cs
+++ b/ChamberLib.OpenTK/BuiltinShaders.cs
@@ -212,7 +212,7 @@ void main(void)
 
     vec4 transformed = worldViewProj * vec4(skinned, 1);
 
-    vf_position_ws = (world * vec4(in_position, 0)).xyz;
+    vf_position_ws = (world * vec4(in_position, 1)).xyz;
 
     vf_normal_ws = (world * vec4(in_normal, 0)).xyz;
 

--- a/ChamberLib.OpenTK/ChamberLib.OpenTK.csproj
+++ b/ChamberLib.OpenTK/ChamberLib.OpenTK.csproj
@@ -31,18 +31,12 @@
     <Reference Include="OpenTK">
       <HintPath>..\packages\OpenTK.1.1.1589.5941\lib\NET40\OpenTK.dll</HintPath>
     </Reference>
-    <Reference Include="OpenTK.GLControl">
-      <HintPath>..\packages\OpenTK.GLControl.1.1.1589.5941\lib\NET40\OpenTK.GLControl.dll</HintPath>
-    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="NAudio">
-      <HintPath>..\..\packages\NAudio.1.7.1\lib\net35\NAudio.dll</HintPath>
+      <HintPath>..\packages\NAudio.1.7.1\lib\net35\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="NVorbis">
-      <HintPath>..\..\packages\NVorbis.0.8.3.0\lib\NVorbis.dll</HintPath>
-    </Reference>
-    <Reference Include="ChamberLib">
-      <HintPath>..\packages\ChamberLib.0.3\lib\net40\ChamberLib.dll</HintPath>
+      <HintPath>..\packages\NVorbis.0.8.3.0\lib\NVorbis.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -97,5 +91,11 @@
     <None Include="packages.config" />
     <None Include="todo.txt" />
     <None Include="ChamberLib.OpenTK.nuspec" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ChamberLib.csproj">
+      <Project>{7DE0B8DB-460B-4455-9BAD-B4FF1280F3CE}</Project>
+      <Name>ChamberLib</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -253,22 +253,6 @@ namespace ChamberLib.OpenTK
             GLHelper.CheckError();
         }
 
-        public void SetUniform(string name, long value)
-        {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
-        }
-
-        public void SetUniform(string name, ulong value)
-        {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
-        }
-
         public void SetUniform(string name, double value)
         {
             Apply();
@@ -338,21 +322,6 @@ namespace ChamberLib.OpenTK
             uint value;
             GL.GetUniform((uint)ProgramID, location, out value);
             return value;
-        }
-
-        public long GetUniformLong(string name)
-        {
-            throw new NotImplementedException();
-//            Apply();
-//            var location = GetUniformLocation(name);
-//            long value;
-//            GL.GetUniform(ProgramID, location, out value);
-//            return value;
-        }
-
-        public ulong GetUniformULong(string name)
-        {
-            throw new NotImplementedException();
         }
 
         public float GetUniformSingle(string name)

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -379,6 +379,11 @@ namespace ChamberLib.OpenTK
             }
         }
 
+        public object GetUniformValue(string name)
+        {
+            return uniformValues[name];
+        }
+
         protected void ApplyUniform(string name)
         {
             var value = uniformValues[name];

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -53,6 +53,15 @@ namespace ChamberLib.OpenTK
             GLHelper.CheckError();
         }
 
+        public bool IsApplied
+        {
+            get
+            {
+                if (ProgramID == 0) return false;
+                return (GL.GetInteger(GetPName.CurrentProgram) == ProgramID);
+            }
+        }
+
         public void MakeReady()
         {
             if (ProgramID != 0)
@@ -352,6 +361,11 @@ namespace ChamberLib.OpenTK
         {
             uniformValues[name] = value;
             uniformTypes[name] = type;
+
+            if (IsApplied)
+            {
+                ApplyUniform(name);
+            }
         }
 
         protected Dictionary<string, object> uniformValues = new Dictionary<string, object>();

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -43,6 +43,8 @@ namespace ChamberLib.OpenTK
 
             GL.ValidateProgram(ProgramID);
             GLHelper.CheckError();
+
+            ApplyUniformValues();
         }
 
         public void UnApply()
@@ -150,46 +152,33 @@ namespace ChamberLib.OpenTK
         }
         public void SetUniform(string name, float value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Single;
         }
         public void SetUniform(string name, Vector2 value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform2(location, value.ToOpenTK());
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Vector2;
         }
         public void SetUniform(string name, Vector3 value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform3(location, value.ToOpenTK());
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Vector3;
         }
         public void SetUniform(string name, Vector4 value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform4(location, value.ToOpenTK());
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Vector4;
         }
         public void SetUniform(string name, Matrix value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            var value2 = value.ToOpenTK();
-            GL.UniformMatrix4(location, false, ref value2);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Matrix;
         }
         public void SetUniform(string name, bool value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, (value ? 1 : 0));
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Bool;
         }
 
         public Matrix GetUniformMatrix(string name)
@@ -207,58 +196,44 @@ namespace ChamberLib.OpenTK
 
         public void SetUniform(string name, byte value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Byte;
         }
 
         public void SetUniform(string name, sbyte value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.SByte;
         }
 
         public void SetUniform(string name, short value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Short;
         }
 
         public void SetUniform(string name, ushort value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.UShort;
         }
 
         public void SetUniform(string name, int value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Int;
         }
 
         public void SetUniform(string name, uint value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.UInt;
         }
 
         public void SetUniform(string name, double value)
         {
-            Apply();
-            var location = GetUniformLocation(name);
-            GL.Uniform1(location, value);
-            GLHelper.CheckError();
+            uniformValues[name] = value;
+            uniformTypes[name] = UniformType.Double;
         }
 
         public bool GetUniformBool(string name)

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -204,6 +204,99 @@ namespace ChamberLib.OpenTK
                 values[8], values[9], values[10], values[11], 
                 values[12], values[13], values[14], values[15]);
         }
+
+        public void SetUniform(string name, byte value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, sbyte value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, short value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, ushort value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, int value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, uint value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, long value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, ulong value)
+        {
+            throw new NotImplementedException();
+        }
+        public void SetUniform(string name, double value)
+        {
+            throw new NotImplementedException();
+        }
+        public bool GetUniformBool(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public byte GetUniformByte(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public sbyte GetUniformSByte(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public short GetUniformShort(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public ushort GetUniformUShort(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public int GetUniformInt(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public uint GetUniformUInt(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public long GetUniformLong(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public ulong GetUniformULong(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public float GetUniformSingle(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public double GetUniformDouble(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public Vector2 GetUniformVector2(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public Vector3 GetUniformVector3(string name)
+        {
+            throw new NotImplementedException();
+        }
+        public Vector4 GetUniformVector4(string name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -368,6 +368,26 @@ namespace ChamberLib.OpenTK
             GL.GetUniform(ProgramID, location, values);
             return new Vector4(values[0], values[1], values[2], values[3]);
         }
+
+        protected enum UniformType
+        {
+            Bool,
+            Byte,
+            SByte,
+            Short,
+            UShort,
+            Int,
+            UInt,
+            Single,
+            Double,
+            Vector2,
+            Vector3,
+            Vector4,
+            Matrix,
+        }
+
+        protected Dictionary<string, object> uniformValues = new Dictionary<string, object>();
+        protected Dictionary<string, UniformType> uniformTypes = new System.Collections.Generic.Dictionary<string, UniformType>();
     }
 }
 

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -207,95 +207,193 @@ namespace ChamberLib.OpenTK
 
         public void SetUniform(string name, byte value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, sbyte value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, short value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, ushort value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, int value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, uint value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, long value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, ulong value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public void SetUniform(string name, double value)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            GL.Uniform1(location, value);
+            GLHelper.CheckError();
         }
+
         public bool GetUniformBool(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            int value;
+            GL.GetUniform(ProgramID, location, out value);
+            return (value != 0);
         }
+
         public byte GetUniformByte(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            uint value;
+            GL.GetUniform((uint)ProgramID, location, out value);
+            return (byte)value;
         }
+
         public sbyte GetUniformSByte(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            int value;
+            GL.GetUniform(ProgramID, location, out value);
+            return (sbyte)value;
         }
+
         public short GetUniformShort(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            int value;
+            GL.GetUniform(ProgramID, location, out value);
+            return (short)value;
         }
+
         public ushort GetUniformUShort(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            uint value;
+            GL.GetUniform((uint)ProgramID, location, out value);
+            return (ushort)value;
         }
+
         public int GetUniformInt(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            int value;
+            GL.GetUniform(ProgramID, location, out value);
+            return value;
         }
+
         public uint GetUniformUInt(string name)
         {
             throw new NotImplementedException();
         }
+
         public long GetUniformLong(string name)
         {
             throw new NotImplementedException();
+//            Apply();
+//            var location = GetUniformLocation(name);
+//            long value;
+//            GL.GetUniform(ProgramID, location, out value);
+//            return value;
         }
+
         public ulong GetUniformULong(string name)
         {
             throw new NotImplementedException();
         }
+
         public float GetUniformSingle(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            float value;
+            GL.GetUniform(ProgramID, location, out value);
+            return value;
         }
+
         public double GetUniformDouble(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            double value;
+            GL.GetUniform(ProgramID, location, out value);
+            return value;
         }
+
         public Vector2 GetUniformVector2(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            float [] values = new float[2];
+            GL.GetUniform(ProgramID, location, values);
+            return new Vector2(values[0], values[1]);
         }
+
         public Vector3 GetUniformVector3(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            float [] values = new float[3];
+            GL.GetUniform(ProgramID, location, values);
+            return new Vector3(values[0], values[1], values[2]);
         }
+
         public Vector4 GetUniformVector4(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            float [] values = new float[4];
+            GL.GetUniform(ProgramID, location, values);
+            return new Vector4(values[0], values[1], values[2], values[3]);
         }
     }
 }

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -333,7 +333,11 @@ namespace ChamberLib.OpenTK
 
         public uint GetUniformUInt(string name)
         {
-            throw new NotImplementedException();
+            Apply();
+            var location = GetUniformLocation(name);
+            uint value;
+            GL.GetUniform((uint)ProgramID, location, out value);
+            return value;
         }
 
         public long GetUniformLong(string name)

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -152,33 +152,27 @@ namespace ChamberLib.OpenTK
         }
         public void SetUniform(string name, float value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Single;
+            SetUniform(name, value, UniformType.Single);
         }
         public void SetUniform(string name, Vector2 value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Vector2;
+            SetUniform(name, value, UniformType.Vector2);
         }
         public void SetUniform(string name, Vector3 value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Vector3;
+            SetUniform(name, value, UniformType.Vector3);
         }
         public void SetUniform(string name, Vector4 value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Vector4;
+            SetUniform(name, value, UniformType.Vector4);
         }
         public void SetUniform(string name, Matrix value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Matrix;
+            SetUniform(name, value, UniformType.Matrix);
         }
         public void SetUniform(string name, bool value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Bool;
+            SetUniform(name, value, UniformType.Bool);
         }
 
         public Matrix GetUniformMatrix(string name)
@@ -196,44 +190,37 @@ namespace ChamberLib.OpenTK
 
         public void SetUniform(string name, byte value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Byte;
+            SetUniform(name, value, UniformType.Byte);
         }
 
         public void SetUniform(string name, sbyte value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.SByte;
+            SetUniform(name, value, UniformType.SByte);
         }
 
         public void SetUniform(string name, short value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Short;
+            SetUniform(name, value, UniformType.Short);
         }
 
         public void SetUniform(string name, ushort value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.UShort;
+            SetUniform(name, value, UniformType.UShort);
         }
 
         public void SetUniform(string name, int value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Int;
+            SetUniform(name, value, UniformType.Int);
         }
 
         public void SetUniform(string name, uint value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.UInt;
+            SetUniform(name, value, UniformType.UInt);
         }
 
         public void SetUniform(string name, double value)
         {
-            uniformValues[name] = value;
-            uniformTypes[name] = UniformType.Double;
+            SetUniform(name, value, UniformType.Double);
         }
 
         public bool GetUniformBool(string name)
@@ -359,6 +346,12 @@ namespace ChamberLib.OpenTK
             Vector3,
             Vector4,
             Matrix,
+        }
+
+        protected void SetUniform(string name, object value, UniformType type)
+        {
+            uniformValues[name] = value;
+            uniformTypes[name] = type;
         }
 
         protected Dictionary<string, object> uniformValues = new Dictionary<string, object>();

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -368,15 +368,14 @@ namespace ChamberLib.OpenTK
         {
             foreach (var name in uniformValues.Keys)
             {
-                var value = uniformValues[name];
-                var type = uniformTypes[name];
-
-                ApplyUniform(name, value, type);
+                ApplyUniform(name);
             }
         }
 
-        protected void ApplyUniform(string name, object value, UniformType type)
+        protected void ApplyUniform(string name)
         {
+            var value = uniformValues[name];
+            var type = uniformTypes[name];
             var location = GetUniformLocation(name);
 
             switch (type)

--- a/ChamberLib.OpenTK/ShaderAdapter.cs
+++ b/ChamberLib.OpenTK/ShaderAdapter.cs
@@ -388,6 +388,71 @@ namespace ChamberLib.OpenTK
 
         protected Dictionary<string, object> uniformValues = new Dictionary<string, object>();
         protected Dictionary<string, UniformType> uniformTypes = new System.Collections.Generic.Dictionary<string, UniformType>();
+
+        protected void ApplyUniformValues()
+        {
+            foreach (var name in uniformValues.Keys)
+            {
+                var value = uniformValues[name];
+                var type = uniformTypes[name];
+
+                ApplyUniform(name, value, type);
+            }
+        }
+
+        protected void ApplyUniform(string name, object value, UniformType type)
+        {
+            var location = GetUniformLocation(name);
+
+            switch (type)
+            {
+            case UniformType.Bool:
+                GL.Uniform1(location, ((bool)value ? 1 : 0));
+                break;
+            case UniformType.Byte:
+                GL.Uniform1(location, (byte)value);
+                break;
+            case UniformType.SByte:
+                GL.Uniform1(location, (sbyte)value);
+                break;
+            case UniformType.Short:
+                GL.Uniform1(location, (short)value);
+                break;
+            case UniformType.UShort:
+                GL.Uniform1(location, (ushort)value);
+                break;
+            case UniformType.Int:
+                GL.Uniform1(location, (int)value);
+                break;
+            case UniformType.UInt:
+                GL.Uniform1(location, (uint)value);
+                break;
+            case UniformType.Single:
+                GL.Uniform1(location, (float)value);
+                break;
+            case UniformType.Double:
+                GL.Uniform1(location, (double)value);
+                break;
+            case UniformType.Vector2:
+                GL.Uniform2(location, ((Vector2)value).ToOpenTK());
+                break;
+            case UniformType.Vector3:
+                GL.Uniform3(location, ((Vector3)value).ToOpenTK());
+                break;
+            case UniformType.Vector4:
+                GL.Uniform4(location, ((Vector4)value).ToOpenTK());
+                break;
+            case UniformType.Matrix:
+                var value2 = ((Matrix)value).ToOpenTK();
+                GL.UniformMatrix4(location, false, ref value2);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    "type",
+                    "Unknown uniform type: " + type.ToString());
+            }
+            GLHelper.CheckError();
+        }
     }
 }
 

--- a/ChamberLib.OpenTK/packages.config
+++ b/ChamberLib.OpenTK/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ChamberLib" version="0.3" targetFramework="net40" />
   <package id="NAudio" version="1.7.1" targetFramework="net40" />
   <package id="NVorbis" version="0.8.3.0" targetFramework="net40" />
   <package id="OpenTK" version="1.1.1589.5941" targetFramework="net40" />
-  <package id="OpenTK.GLControl" version="1.1.1589.5941" targetFramework="net40" />
 </packages>

--- a/ChamberLibTests/ChamberLibTests.csproj
+++ b/ChamberLibTests/ChamberLibTests.csproj
@@ -31,9 +31,6 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="ChamberLib">
-      <HintPath>..\packages\ChamberLib.0.3\lib\net40\ChamberLib.dll</HintPath>
-    </Reference>
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
@@ -47,5 +44,11 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ChamberLib.csproj">
+      <Project>{7DE0B8DB-460B-4455-9BAD-B4FF1280F3CE}</Project>
+      <Name>ChamberLib</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/ChamberLibTests/packages.config
+++ b/ChamberLibTests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ChamberLib" version="0.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/Content/ChModelImporter.cs
+++ b/Content/ChModelImporter.cs
@@ -29,7 +29,7 @@ namespace ChamberLib.Content
             }
             else
             {
-                throw new FileNotFoundException("The file could not be found", filename);
+                throw new FileNotFoundException("The file could not be found: " + filename, filename);
             }
 
             using (var s = new StreamReader(filename))

--- a/IShader.cs
+++ b/IShader.cs
@@ -22,20 +22,6 @@ namespace ChamberLib
         void SetUniform(string name, Vector3 value);
         void SetUniform(string name, Vector4 value);
         void SetUniform(string name, Matrix value);
-
-        bool GetUniformBool(string name);
-        byte GetUniformByte(string name);
-        sbyte GetUniformSByte(string name);
-        short GetUniformShort(string name);
-        ushort GetUniformUShort(string name);
-        int GetUniformInt(string name);
-        uint GetUniformUInt(string name);
-        float GetUniformSingle(string name);
-        double GetUniformDouble(string name);
-        Vector2 GetUniformVector2(string name);
-        Vector3 GetUniformVector3(string name);
-        Vector4 GetUniformVector4(string name);
-        Matrix GetUniformMatrix(string name);
     }
 }
 

--- a/IShader.cs
+++ b/IShader.cs
@@ -16,8 +16,6 @@ namespace ChamberLib
         void SetUniform(string name, ushort value);
         void SetUniform(string name, int value);
         void SetUniform(string name, uint value);
-        void SetUniform(string name, long value);
-        void SetUniform(string name, ulong value);
         void SetUniform(string name, float value);
         void SetUniform(string name, double value);
         void SetUniform(string name, Vector2 value);
@@ -32,8 +30,6 @@ namespace ChamberLib
         ushort GetUniformUShort(string name);
         int GetUniformInt(string name);
         uint GetUniformUInt(string name);
-        long GetUniformLong(string name);
-        ulong GetUniformULong(string name);
         float GetUniformSingle(string name);
         double GetUniformDouble(string name);
         Vector2 GetUniformVector2(string name);

--- a/IShader.cs
+++ b/IShader.cs
@@ -8,6 +8,38 @@ namespace ChamberLib
 
         void Apply();
         void UnApply();
+
+        void SetUniform(string name, bool value);
+        void SetUniform(string name, byte value);
+        void SetUniform(string name, sbyte value);
+        void SetUniform(string name, short value);
+        void SetUniform(string name, ushort value);
+        void SetUniform(string name, int value);
+        void SetUniform(string name, uint value);
+        void SetUniform(string name, long value);
+        void SetUniform(string name, ulong value);
+        void SetUniform(string name, float value);
+        void SetUniform(string name, double value);
+        void SetUniform(string name, Vector2 value);
+        void SetUniform(string name, Vector3 value);
+        void SetUniform(string name, Vector4 value);
+        void SetUniform(string name, Matrix value);
+
+        bool GetUniformBool(string name);
+        byte GetUniformByte(string name);
+        sbyte GetUniformSByte(string name);
+        short GetUniformShort(string name);
+        ushort GetUniformUShort(string name);
+        int GetUniformInt(string name);
+        uint GetUniformUInt(string name);
+        long GetUniformLong(string name);
+        ulong GetUniformULong(string name);
+        float GetUniformSingle(string name);
+        double GetUniformDouble(string name);
+        Vector2 GetUniformVector2(string name);
+        Vector3 GetUniformVector3(string name);
+        Vector4 GetUniformVector4(string name);
+        Matrix GetUniformMatrix(string name);
     }
 }
 


### PR DESCRIPTION
This PR re-works the `IShader` interface so that we can call `SetUniform` without having to talk to the `ShaderAdapter` class directly.
