### PR TITLE
Fix/move set bone transforms

### DIFF
--- a/ChamberLib.OpenTK/Model.cs
+++ b/ChamberLib.OpenTK/Model.cs
@@ -144,7 +144,7 @@ namespace ChamberLib.OpenTK
         {
         }
 
-        public void SetBoneTransforms(Matrix[] boneTransforms, float verticalOffset, Matrix world)
+        public void SetBoneTransforms(Matrix[] boneTransforms)
         {
             if (boneTransforms == null) throw new ArgumentNullException("boneTransforms");
 

--- a/ChamberLib.OpenTK/Model.cs
+++ b/ChamberLib.OpenTK/Model.cs
@@ -146,28 +146,17 @@ namespace ChamberLib.OpenTK
 
         public void SetBoneTransforms(Matrix[] boneTransforms, float verticalOffset, Matrix world)
         {
-            throw new NotImplementedException();
+            if (boneTransforms == null) throw new ArgumentNullException("boneTransforms");
+
             foreach (var material in GetAllMaterials())
             {
                 if (material.Shader != BuiltinShaders.BasicShader)
                 {
-                    if (boneTransforms != null)
+                    int i;
+                    for (i = 0; i < 32 && i < boneTransforms.Length; i++)
                     {
-                        int i;
-                        for (i = 0; i < 32 && i < boneTransforms.Length; i++)
-                        {
-                            var name = string.Format("bones[{0}]", i);
-                            material.Shader2.SetUniform(name, boneTransforms[i]);
-                        }
-                    }
-                    else
-                    {
-                        int i;
-                        for (i = 0; i < 32; i++)
-                        {
-                            var name = string.Format("bones[{0}]", i);
-                            material.Shader2.SetUniform(name, Matrix.Identity);
-                        }
+                        var name = string.Format("bones[{0}]", i);
+                        material.Shader2.SetUniform(name, boneTransforms[i]);
                     }
 
                     break;

--- a/ChamberLib.OpenTK/Model.cs
+++ b/ChamberLib.OpenTK/Model.cs
@@ -151,7 +151,7 @@ namespace ChamberLib.OpenTK
             foreach (var material in GetAllMaterials())
             {
                 int i;
-                for (i = 0; i < 32 && i < boneTransforms.Length; i++)
+                for (i = 0; i < boneTransforms.Length; i++)
                 {
                     var name = string.Format("bones[{0}]", i);
                     material.Shader2.SetUniform(name, boneTransforms[i]);

--- a/ChamberLib.OpenTK/Model.cs
+++ b/ChamberLib.OpenTK/Model.cs
@@ -146,9 +146,10 @@ namespace ChamberLib.OpenTK
 
         public void SetBoneTransforms(Matrix[] boneTransforms, float verticalOffset, Matrix world)
         {
+            throw new NotImplementedException();
             foreach (var material in GetAllMaterials())
             {
-                if (material.Shader == BuiltinShaders.SkinnedShader)
+                if (material.Shader != BuiltinShaders.BasicShader)
                 {
                     if (boneTransforms != null)
                     {
@@ -156,7 +157,7 @@ namespace ChamberLib.OpenTK
                         for (i = 0; i < 32 && i < boneTransforms.Length; i++)
                         {
                             var name = string.Format("bones[{0}]", i);
-                            BuiltinShaders.SkinnedShader.SetUniform(name, boneTransforms[i]);
+                            material.Shader2.SetUniform(name, boneTransforms[i]);
                         }
                     }
                     else
@@ -165,7 +166,7 @@ namespace ChamberLib.OpenTK
                         for (i = 0; i < 32; i++)
                         {
                             var name = string.Format("bones[{0}]", i);
-                            BuiltinShaders.SkinnedShader.SetUniform(name, Matrix.Identity);
+                            material.Shader2.SetUniform(name, Matrix.Identity);
                         }
                     }
 

--- a/ChamberLib.OpenTK/Model.cs
+++ b/ChamberLib.OpenTK/Model.cs
@@ -150,16 +150,11 @@ namespace ChamberLib.OpenTK
 
             foreach (var material in GetAllMaterials())
             {
-                if (material.Shader != BuiltinShaders.BasicShader)
+                int i;
+                for (i = 0; i < 32 && i < boneTransforms.Length; i++)
                 {
-                    int i;
-                    for (i = 0; i < 32 && i < boneTransforms.Length; i++)
-                    {
-                        var name = string.Format("bones[{0}]", i);
-                        material.Shader2.SetUniform(name, boneTransforms[i]);
-                    }
-
-                    break;
+                    var name = string.Format("bones[{0}]", i);
+                    material.Shader2.SetUniform(name, boneTransforms[i]);
                 }
             }
         }

--- a/IModel.cs
+++ b/IModel.cs
@@ -26,7 +26,7 @@ namespace ChamberLib
 
         void SetWorldViewProjection(Matrix transform, Matrix view, Matrix projection);
 
-        void SetBoneTransforms(Matrix[] boneTransforms, float verticalOffset, Matrix world);
+        void SetBoneTransforms(Matrix[] boneTransforms);
     }
 }
 


### PR DESCRIPTION
This PR cleans up the `SetBoneTransforms` method in the `IModel` interface and `Model` class. It fixes, rather than moves, the method.
