### PR TITLE
Fix viewports & textures

### DIFF
--- a/ChamberLib.OpenTK/FrameBuffer.cs
+++ b/ChamberLib.OpenTK/FrameBuffer.cs
@@ -77,7 +77,7 @@ namespace ChamberLib.OpenTK
             GL.ClearBuffer(ClearBuffer.Depth, 0, ref one); 
             GL.ClearBuffer(ClearBuffer.Color, 0, black);
 
-            Renderer.Viewport = new Viewport(0, 0, Width, Height);
+            Renderer.SetViewport(new Viewport(0, 0, Width, Height), false);
         }
 
         public void UnApply()

--- a/ChamberLib.OpenTK/FrameBuffer.cs
+++ b/ChamberLib.OpenTK/FrameBuffer.cs
@@ -69,7 +69,7 @@ namespace ChamberLib.OpenTK
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, ID);
             GLHelper.CheckError();
 
-            GL.DrawBuffer(DrawBufferMode.ColorAttachment0);//(DrawBufferMode)FramebufferAttachment.ColorAttachment0Ext);
+            GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
             GLHelper.CheckError();
 
             float one = 1;

--- a/ChamberLib.OpenTK/FrameBuffer.cs
+++ b/ChamberLib.OpenTK/FrameBuffer.cs
@@ -72,12 +72,13 @@ namespace ChamberLib.OpenTK
             GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
             GLHelper.CheckError();
 
+            Renderer.SetViewport(new Viewport(0, 0, Width, Height), false);
+
             float one = 1;
             int [] black = new int[]{ 0, 0, 0, 0 };
             GL.ClearBuffer(ClearBuffer.Depth, 0, ref one); 
             GL.ClearBuffer(ClearBuffer.Color, 0, black);
 
-            Renderer.SetViewport(new Viewport(0, 0, Width, Height), false);
         }
 
         public void UnApply()

--- a/ChamberLib.OpenTK/Renderer.cs
+++ b/ChamberLib.OpenTK/Renderer.cs
@@ -47,17 +47,25 @@ namespace ChamberLib.OpenTK
             }
             set
             {
-                _viewport = value;
-
-                GL.Viewport(
-                    value.X,
-                    _subsystem.Window.Height - value.Y - value.Height,
-                    value.Width,
-                    value.Height
-                );
-                GLHelper.CheckError();
+                SetViewport(value);
             }
         }
+        public void SetViewport(Viewport value, bool windowed=true)
+        {
+            _viewport = value;
+
+            var height = (windowed ? _subsystem.Window.Height : value.Height);
+            var y = height - value.Y - value.Height;
+
+            GL.Viewport(
+                value.X,
+                y,
+                value.Width,
+                value.Height
+            );
+            GLHelper.CheckError();
+        }
+
         #endregion
 
         public void Reset2D()

--- a/ChamberLib.OpenTK/TextureAdapter.cs
+++ b/ChamberLib.OpenTK/TextureAdapter.cs
@@ -55,15 +55,24 @@ namespace ChamberLib.OpenTK
             switch (PixelFormat)
             {
             case PixelFormat.Rgba:
-                n = PixelData.Length * 4;
+                var numpixels = Width * Height;
+                n = numpixels * 4;
                 var bytes = new byte[n];
-                for (i = 0; i < n; i += 4)
+                var last = ( (PixelData == null || PixelData.Length <= 0) ? Color.Black : PixelData[PixelData.Length - 1]);
+                for (i = 0; i < 4*PixelData.Length; i += 4)
                 {
                     var c = PixelData[i / 4];
                     bytes[i] = c.A;
                     bytes[i + 1] = c.R;
                     bytes[i + 2] = c.G;
                     bytes[i + 3] = c.B;
+                }
+                for (; i < n; i += 4)
+                {
+                    bytes[i] = last.A;
+                    bytes[i + 1] = last.R;
+                    bytes[i + 2] = last.G;
+                    bytes[i + 3] = last.B;
                 }
 
                 GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, Width, Height, 0,

--- a/ChamberLib.OpenTK/todo.txt
+++ b/ChamberLib.OpenTK/todo.txt
@@ -1,3 +1,3 @@
-load fbx files
 gamepads
 mp3?
+move ChModelExporter to ChamberLib

--- a/Color.cs
+++ b/Color.cs
@@ -50,6 +50,11 @@ namespace ChamberLib
         {
             return new Color(Vector3Colors.FromHslVector(h,s,l));
         }
+
+        public int[] ToIntegerArrayRgba()
+        {
+            return new int[] { R, G, B, A };
+        }
     }
 }
 

--- a/IRenderer.cs
+++ b/IRenderer.cs
@@ -23,6 +23,7 @@ namespace ChamberLib
         void DrawLines(Vector3 color, Matrix world, Matrix view, Matrix projection, IEnumerable<Vector3> vs);
 
         Viewport Viewport { get; set; }
+        void SetViewport(Viewport value, bool windowed=true);
     }
 
     public struct DrawImagesEntry


### PR DESCRIPTION
This PR makes changes to how viewports are set, in order to fix a problem with shadow maps.
This PR also fixes a bug in `TextureAdapter.MakeReady` that was causing OpenGL to fail on Windows.
